### PR TITLE
prevent adding None as fulfillment / condition to Transaction

### DIFF
--- a/bigchaindb_common/transaction.py
+++ b/bigchaindb_common/transaction.py
@@ -499,18 +499,14 @@ class Transaction(object):
         return inputs
 
     def add_fulfillment(self, fulfillment):
-        if (fulfillment is not None and not
-                isinstance(fulfillment, Fulfillment)):
-            raise TypeError('`fulfillment` must be a Fulfillment instance or '
-                            'None')
-        else:
-            self.fulfillments.append(fulfillment)
+        if not isinstance(fulfillment, Fulfillment):
+            raise TypeError('`fulfillment` must be a Fulfillment instance')
+        self.fulfillments.append(fulfillment)
 
     def add_condition(self, condition):
-        if condition is not None and not isinstance(condition, Condition):
+        if not isinstance(condition, Condition):
             raise TypeError('`condition` must be a Condition instance or None')
-        else:
-            self.conditions.append(condition)
+        self.conditions.append(condition)
 
     def sign(self, private_keys):
         # TODO: Singing should be possible with at least one of all private

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -1087,3 +1087,17 @@ def test_create_transfer_with_invalid_parameters():
         Transaction.transfer(['fulfillment'], {}, Asset())
     with raises(ValueError):
         Transaction.transfer(['fulfillment'], [], Asset())
+
+
+def test_cant_add_empty_condition():
+    from bigchaindb_common.transaction import Transaction
+    tx = Transaction(Transaction.CREATE, None)
+    with raises(TypeError):
+        tx.add_condition(None)
+
+
+def test_cant_add_empty_fulfillment():
+    from bigchaindb_common.transaction import Transaction
+    tx = Transaction(Transaction.CREATE, None)
+    with raises(TypeError):
+        tx.add_fulfillment(None)


### PR DESCRIPTION
Prevent the following:

``` python
(Pdb) tx = Transaction("CREATE")
(Pdb) tx.to_dict()
{'id': 'eebc821c50bf893c0da1fc4de897a8807e7dbe1cd966745ad989c12cdc53cefd', 'transaction': {'operation': 'CREATE', 'data': None, 'timestamp': 42, 'conditions': [], 'fulfillments': []}, 'version': 1}
(Pdb) tx.add_condition(None)
(Pdb) tx.to_dict()
*** AttributeError: 'NoneType' object has no attribute 'to_dict'
```
