### PR TITLE
Created docs/requirements.txt for ReadTheDocs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,7 @@
+# we need this for readthedocs
+
+sphinx
+sphinx-autobuild
+sphinxcontrib-httpdomain
+sphinxcontrib-napoleon
+sphinx_rtd_theme


### PR DESCRIPTION
The initial version is just a copy of `docs/requirements.txt` in bigchaindb-driver.
